### PR TITLE
Form validation and submission

### DIFF
--- a/app/controllers/adopt_apps_controller.rb
+++ b/app/controllers/adopt_apps_controller.rb
@@ -16,16 +16,21 @@ class AdoptAppsController < ApplicationController
     redirect_to "/adopt_apps/#{@adopt_app.id}"
   end
 
+  def new 
+  end
+
   def create
     app = AdoptApp.create(app_params)
-
-    redirect_to "/adopt_apps/#{app.id}"
+    if app.valid?
+      redirect_to "/adopt_apps/#{app.id}"
+    else 
+      @errors = app.errors.full_messages
+      render :new
+    end 
   end
 
   private 
   def app_params
     params.permit(:id, :name, :street_address, :city, :state, :zip_code, :status)
   end
-
-
 end

--- a/app/models/adopt_app.rb
+++ b/app/models/adopt_app.rb
@@ -1,4 +1,10 @@
 class AdoptApp < ApplicationRecord
+  validates_presence_of :name
+  validates_presence_of :street_address
+  validates_presence_of :city
+  validates_presence_of :state
+  validates_presence_of :zip_code
+
   has_many :adopt_app_pets
   has_many :pets, through: :adopt_app_pets
 end

--- a/app/views/adopt_apps/new.html.erb
+++ b/app/views/adopt_apps/new.html.erb
@@ -13,5 +13,11 @@
   <%= form.text_field :zip_code %></p>
   <%= form.hidden_field :status, :value => "In Progress" %>
   <%= form.submit "Submit" %>
-  
+<% end %>
+
+<% if @errors != nil %>
+<h2>Please correct the following errors:</h2>
+  <% @errors.each do |error| %>
+    <h4><%= error %></h4>
+  <% end %>
 <% end %>

--- a/spec/features/adopt_apps/create_spec.rb
+++ b/spec/features/adopt_apps/create_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe 'Application creation' do
 
       end
     end
+
+    context 'given invalid data' do 
+      it 'redirects the user back to new applications page and displays a message to fill in missing fields' do
+        visit 'adopt_apps/new'
+
+        fill_in 'Name', with: 'Kristen Nestler'
+        fill_in 'Street address', with: '111 N. Broadway, E11'
+        fill_in 'City', with: 'White Plains'
+        click_button "Submit"
+
+        expect(current_path).to eq('/adopt_apps/new')
+        save_and_open_page
+
+        expect(page).to have_content("State can't be blank")
+        expect(page).to have_content("Zip code can't be blank")
+      end
+    end
   end
 
 end

--- a/spec/features/adopt_apps/create_spec.rb
+++ b/spec/features/adopt_apps/create_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe 'Application creation' do
         click_button "Submit"
 
         expect(current_path).to eq('/adopt_apps/new')
-        save_and_open_page
-
         expect(page).to have_content("State can't be blank")
         expect(page).to have_content("Zip code can't be blank")
       end

--- a/spec/models/adopt_app_spec.rb
+++ b/spec/models/adopt_app_spec.rb
@@ -5,4 +5,12 @@ RSpec.describe AdoptApp, type: :model do
     it { should have_many :adopt_app_pets }
     it { should have_many(:pets).through(:adopt_app_pets) }
   end
+
+  describe "validations" do 
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :street_address }
+    it { should validate_presence_of :city }
+    it { should validate_presence_of :state }
+    it { should validate_presence_of :zip_code }
+  end
 end 


### PR DESCRIPTION
Complete feature in user story 3 -> requires the new adoption application form to have all fields filled out. If not, it does not add the app to the adopt_apps table and redirects the user back to the new page, with a message that says which fields they still need to fill out. In doing this, I added validations to the adopt_app model: it validates the presence of name, street_address, city, state, and zip_code. Associated model tests have also been added. 